### PR TITLE
Add `HtmlEval` instance for elections

### DIFF
--- a/Apportionmentlib/Basic.lean
+++ b/Apportionmentlib/Basic.lean
@@ -7,6 +7,7 @@ import Mathlib.Algebra.BigOperators.Group.Finset.Basic
 import Mathlib.Data.Finset.Basic
 import Mathlib.Data.Nat.Dist
 import Mathlib.Data.Rat.Floor
+import ProofWidgets.Component.HtmlDisplay
 import Apportionmentlib.Utils
 
 /-!
@@ -49,7 +50,8 @@ between weak and strong exactness is added, following [PalomaresPukelsheimRamire
 
 -/
 
-open BigOperators
+open BigOperators ProofWidgets
+open Lean (Json)
 
 namespace Apportionmentlib
 
@@ -64,10 +66,47 @@ structure Election (n : ℕ) where
 instance {n : ℕ} : Repr (Election n) where
   reprPrec e _ :=
     "[" ++ repr e.houseSize ++ "; " ++ repr e.votes.toList ++ "]"
-    -- "{ votes := " ++ repr e.votes.toArray ++ ", houseSize := " ++ repr e.houseSize ++ " }"
 
 macro "election![" seats:term ";" "[" votes:term,* "]" "]" : term =>
   `(Apportionmentlib.Election.mk #v[$votes,*] $seats (by decide))
+
+private def Election.toHtml {n : ℕ} (e : Election n) : Html :=
+  let indices := List.range n
+  let votesList := e.votes.toList
+  let houseSize := e.houseSize
+  let total := votesList.sum
+  let thStyle := Json.mkObj [
+    ("border", Json.str "1px solid"),
+    ("padding", Json.str "6px"),
+    ("textAlign", Json.str "center")
+  ]
+  let tdStyle := Json.mkObj [
+    ("border", Json.str "1px solid"),
+    ("padding", Json.str "6px"),
+    ("textAlign", Json.str "center"),
+    ("fontFamily", Json.str "monospace")
+  ]
+  let tableStyle := Json.mkObj [
+    ("borderCollapse", Json.str "collapse"),
+  ]
+  let th (s : String) := Html.element "th" #[("style", thStyle)] #[Html.text s]
+  let td (s : String) := Html.element "td" #[("style", tdStyle)] #[Html.text s]
+  let row1 := Html.element "tr" #[] <|
+    ([th "id"] ++ indices.map (fun i => th (toString i)) ++ [th "Σ"]).toArray
+  let row2 := Html.element "tr" #[] <|
+    ([th "votes"] ++ votesList.map (fun v => td (toString v)) ++ [td s!"{total}"]).toArray
+  let row3 := Html.element "tr" #[] <|
+    ([th "quota"] ++ votesList.map (fun v => td (formatRat4 ((v : ℚ) / total * houseSize))) ++
+     [td s!"{houseSize.val}"]).toArray
+  Html.element "table" #[("style", tableStyle)] #[Html.element "tbody" #[] #[row1, row2, row3]]
+
+/-- This instance enables rendering of elections using the `#html` command. For example,
+```lean
+#html election![8; [66, 67, 245, 622]]
+```
+-/
+instance {n : ℕ} : HtmlEval (Election n) where
+  eval e := pure e.toHtml
 
 /-- Create a new election by permuting the vote distribution of parties according to permutation
 `σ`. -/

--- a/Apportionmentlib/Utils.lean
+++ b/Apportionmentlib/Utils.lean
@@ -10,8 +10,22 @@ import Mathlib.Tactic
 /-!
 # Utils
 
-Utility lemmas for Apportionmentlib.
+Utility functions and lemmas for Apportionmentlib.
 -/
+
+private def padLeft (s : String) (n : Nat) (c : Char) : String :=
+  let padLen := n - s.length
+  if padLen > 0 then ("".pushn c padLen) ++ s else s
+
+/-- Formats a rational number to four decimal places. -/
+def formatRat4 (r : Rat) : String :=
+  let scaled := (r * 10000).floor
+  let sign := if scaled < 0 then "-" else ""
+  let absVal := scaled.natAbs
+  let intPart := absVal / 10000
+  let fracPart := absVal % 10000
+  let fracStr := padLeft (toString fracPart) 4 '0'
+  s!"{sign}{intPart}.{fracStr}"
 
 /-- A vector of natural numbers has positive sum iff at least one component is positive. -/
 lemma sum_pos_iff_exists_pos {n : ℕ} {v : Vector ℕ n} : 0 < v.sum ↔ ∃ i : Fin n, 0 < v[i] := by


### PR DESCRIPTION
You can now use:
```lean4
#html election![8; [66, 67, 245, 622]]
```
to visualize an election instance in VS Code as a table with quotas!